### PR TITLE
fix: removal api only change subscription status

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ With these routes in place, you can create and delete subscriptions by making ap
 
 To create a customer: POST /api/v0/customers?params
 To create a subscription for a customer: POST /api/v0/subscriptions?params
-To delete a subscription for a customer: DELETE /api/v0/subscriptions?params
+To delete a subscription for a customer: DELETE "/api/v0/subscriptions/[subscription_id]?customer_id=[customer_id]"
 
 Without user accounts and authentication, these endpoints were created such that the customer email address is used for identification, as using an ID# would allow bad actors to scour the entire database.

--- a/app/controllers/api/v0/subscriptions_controller.rb
+++ b/app/controllers/api/v0/subscriptions_controller.rb
@@ -10,15 +10,18 @@ class Api::V0::SubscriptionsController < ApplicationController
   end
 
   def destroy
-    subscription = Subscription.find(removal_params[:id])
-    if subscription.customer_id == removal_params[:customer_id].to_i
-      if subscription.update(status: "cancelled")
-        render json: { message: 'Subscription successfully cancelled' }, status: :ok
+    if subscription = Subscription.find(removal_params[:id])
+      if customer = Customer.find_by(email: removal_params[:customer_email])
+        if subscription.update(status: "cancelled")
+          render json: { message: 'Subscription successfully cancelled' }, status: :ok
+        else
+          # Future sad path logic... render json: { error: 'Failed to update the subscription status' }, status: :unprocessable_entity
+        end
       else
-        # Future sad path logic... render json: { error: 'Failed to update the subscription status' }, status: :unprocessable_entity
+        # Future sad path logic... render json: { error: 'Cannot be processed' }, status: :422
       end
     else
-      # Future sad path logic... render json: { error: 'Cannot be processed' }, status: :422
+      # Future sad path logic
     end
   end
 
@@ -29,6 +32,6 @@ class Api::V0::SubscriptionsController < ApplicationController
   end
 
   def removal_params
-    params.require(:subscription).permit(:id, :customer_id)
+    params.require(:subscription).permit(:id, :customer_email)
   end
 end

--- a/spec/requests/api/v0/remove_subscription_spec.rb
+++ b/spec/requests/api/v0/remove_subscription_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Remove Subscription', type: :request do
       customer = create(:customer)
       tea = Tea.all.first
       subscription = Subscription.create!(title: "Monthly English Breakfast", price: 7.95, customer_id: customer.id, tea_id: tea.id, status: "active", frequency_months: 1)
-      valid_params = { subscription: { id: subscription.id, customer_id: customer.id }}
+      valid_params = { subscription: { id: subscription.id, customer_email: customer.email}}
 
       delete "/api/v0/subscriptions/#{subscription.id}", params: valid_params
 


### PR DESCRIPTION
The previous Pull Request assumed that the Subscription should be removed.  However, it is clear that the record should remain but the `status` should be changed to `"canceled"`

Create an API for canceling a subscription:
`patch /api/v0/customers/[customer_id]/subscriptions/[subscription_id]  `
Required params as `JSON` in the `Body` of the request: `{ "subscription": { "status": "cancel"}}`