### PR TITLE
Fix customer id requirement in subscription api

### DIFF
--- a/app/controllers/api/v0/subscriptions_controller.rb
+++ b/app/controllers/api/v0/subscriptions_controller.rb
@@ -10,20 +10,14 @@ class Api::V0::SubscriptionsController < ApplicationController
   end
   
   def create
-    require 'pry'; binding.pry
-    if subscription_params[:customer_id].nil? || subscription_params[:tea_id].nil?
-      render json: { error: 'Unable to process this request' }, status: :unprocessable_entity
-      return
-    end
-
-    customer = Customer.find(subscription_params[:customer_id])
-    tea = Tea.find(subscription_params[:tea_id])
-    found_subscription = Subscription.find_by(customer_id: subscription_params[:customer_id], tea_id: subscription_params[:tea_id])
+    customer = Customer.find_by(id: params[:customer_id])
+    tea = Tea.find_by(id: subscription_params[:tea_id])
+    found_subscription = Subscription.find_by(customer_id: params[:customer_id], tea_id: subscription_params[:tea_id])
   
     if found_subscription
       render json: { error: 'Unable to process this request' }, status: :unprocessable_entity
     else
-      subscription = Subscription.new(subscription_params)
+      subscription = Subscription.new(title: subscription_params[:title], price: subscription_params[:price], tea_id: subscription_params[:tea_id], status: subscription_params[:status], frequency_months: subscription_params[:frequency_months], customer_id: params[:customer_id])
   
       if subscription.save
         render json: subscription, status: :created
@@ -54,7 +48,7 @@ class Api::V0::SubscriptionsController < ApplicationController
   private
 
   def subscription_params
-    params.require(:subscription).permit(:title, :price, :customer_id, :tea_id, :status, :frequency_months)
+    params.require(:subscription).permit(:title, :price, :tea_id, :status, :frequency_months)
   end
 
   def removal_params

--- a/app/controllers/api/v0/subscriptions_controller.rb
+++ b/app/controllers/api/v0/subscriptions_controller.rb
@@ -10,6 +10,7 @@ class Api::V0::SubscriptionsController < ApplicationController
   end
   
   def create
+    require 'pry'; binding.pry
     if subscription_params[:customer_id].nil? || subscription_params[:tea_id].nil?
       render json: { error: 'Unable to process this request' }, status: :unprocessable_entity
       return

--- a/spec/requests/api/v0/add_subscription_spec.rb
+++ b/spec/requests/api/v0/add_subscription_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'POST /api/v0/subscriptions', type: :request do
     it 'creates a new subscription' do
       customer = create(:customer)
       tea_selection = Tea.all.first
-      valid_params = { subscription: { title: "Monthly English Breakfast", price: 7.95, customer_id: customer.id, tea_id: tea_selection.id, status: "active", frequency_months: 1 } }
+      valid_params = { subscription: { title: "Monthly English Breakfast", price: 7.95,tea_id: tea_selection.id, status: "active", frequency_months: 1 } }
       post "/api/v0/customers/#{customer.id}/subscriptions", params: valid_params
 
       expect(response).to have_http_status(:created)
@@ -16,9 +16,9 @@ RSpec.describe 'POST /api/v0/subscriptions', type: :request do
     it 'returns bad request when email is not unique' do
       customer = create(:customer)
       tea_selection = Tea.all.first
-      subscription = Subscription.create!(title: "Monthly English Breakfast", price: 7.95, customer_id: customer.id, tea_id: tea_selection.id, status: "active", frequency_months: 1)
+      subscription = Subscription.create!(title: "Monthly English Breakfast", price: 7.95, tea_id: tea_selection.id, status: "active", frequency_months: 1)
 
-      valid_params = { subscription: { title: "Monthly English Breakfast", price: 7.95, customer_id: customer.id, tea_id: tea_selection.id, status: "active", frequency_months: 1 } }
+      valid_params = { subscription: { title: "Monthly English Breakfast", price: 7.95, tea_id: tea_selection.id, status: "active", frequency_months: 1 } }
       post "/api/v0/customers/#{customer.id}/subscriptions", params: valid_params
 
       expect(response).to have_http_status(:unprocessable_entity)
@@ -42,18 +42,10 @@ RSpec.describe 'POST /api/v0/subscriptions', type: :request do
 
       expect(response).to have_http_status(:unprocessable_entity)
     end
-    it 'returns bad request when missing customer_id' do
-      customer = create(:customer)
-      tea_selection = Tea.all.first
-      valid_params = { subscription: { title: "Monthly English Breakfast", price: 7.95, tea_id: tea_selection.id, status: "active", frequency_months: 1 } }
-      post "/api/v0/customers/#{customer.id}/subscriptions", params: valid_params
-
-      expect(response).to have_http_status(:unprocessable_entity)
-    end
     it 'returns bad request when missing tea_id' do
       customer = create(:customer)
       tea_selection = Tea.all.first
-      valid_params = { subscription: { title: "Monthly English Breakfast", price: 7.95, customer_id: customer.id, status: "active", frequency_months: 1 } }
+      valid_params = { subscription: { title: "Monthly English Breakfast", price: 7.95, status: "active", frequency_months: 1 } }
       post "/api/v0/customers/#{customer.id}/subscriptions", params: valid_params
 
       expect(response).to have_http_status(:unprocessable_entity)
@@ -61,7 +53,7 @@ RSpec.describe 'POST /api/v0/subscriptions', type: :request do
     it 'returns bad request when missing status' do
       customer = create(:customer)
       tea_selection = Tea.all.first
-      valid_params = { subscription: { title: "Monthly English Breakfast", price: 7.95, customer_id: customer.id, tea_id: tea_selection.id, frequency_months: 1 } }
+      valid_params = { subscription: { title: "Monthly English Breakfast", price: 7.95, tea_id: tea_selection.id, frequency_months: 1 } }
       post "/api/v0/customers/#{customer.id}/subscriptions", params: valid_params
 
       expect(response).to have_http_status(:unprocessable_entity)
@@ -69,7 +61,7 @@ RSpec.describe 'POST /api/v0/subscriptions', type: :request do
     it 'returns bad request when missing frequency' do
       customer = create(:customer)
       tea_selection = Tea.all.first
-      valid_params = { subscription: { title: "Monthly English Breakfast", price: 7.95, customer_id: customer.id, tea_id: tea_selection.id, status: "active" } }
+      valid_params = { subscription: { title: "Monthly English Breakfast", price: 7.95, tea_id: tea_selection.id, status: "active" } }
       post "/api/v0/customers/#{customer.id}/subscriptions", params: valid_params
 
       expect(response).to have_http_status(:unprocessable_entity)

--- a/spec/requests/api/v0/add_subscription_spec.rb
+++ b/spec/requests/api/v0/add_subscription_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe 'POST /api/v0/subscriptions', type: :request do
   end
   
   describe 'handles subscription duplication' do
-    it 'returns bad request when email is not unique' do
+    it 'returns bad request when the subscription already exists' do
       customer = create(:customer)
       tea_selection = Tea.all.first
-      subscription = Subscription.create!(title: "Monthly English Breakfast", price: 7.95, tea_id: tea_selection.id, status: "active", frequency_months: 1)
+      subscription = Subscription.create!(title: "Monthly English Breakfast", price: 7.95, customer_id: customer.id, tea_id: tea_selection.id, status: "active", frequency_months: 1)
 
       valid_params = { subscription: { title: "Monthly English Breakfast", price: 7.95, tea_id: tea_selection.id, status: "active", frequency_months: 1 } }
       post "/api/v0/customers/#{customer.id}/subscriptions", params: valid_params


### PR DESCRIPTION
Removed customer_id requirement from JSON request.  Updated tests and features.  All local tests are complete and tests via Postman

Closes #25 